### PR TITLE
Fixed routes being specific, making it hard to get aggreate data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,12 +17,8 @@ module.exports = function (options) {
 			res.end = end;
 			res.end(chunk, encoding);
 
-			if (!req.originalUrl) {
-				return;
-			}
-
 			var statTags = [
-				"route:" + req.originalUrl
+				"route:" + req.route.path,
 			].concat(tags);
 
 			if (options.method) {


### PR DESCRIPTION
Not sure why I did this before, but using `originalUrl` made every id a unique tag. This will lump them all under the same tag.

That is, `/orders/:id` instead of `/orders/1`, `/orders/2`, `/orders/3`, ...