### PR TITLE
MB-4248: Fix datadog causing app crash when an invalid path is given

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,14 +7,6 @@ test:
     - echo "no tests"
 
 deployment:
-  feature:
-    branch: /feature.*/
-    commands:
-      - npm publish
-  bugfix:
-    branch: /bugfix.*/
-    commands:
-      - npm publish
   prod:
     branch: master
     commands:

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,9 @@ module.exports = function (options) {
 			res.end = end;
 			res.end(chunk, encoding);
 
+			var route = req.route ? req.route.path : req.originalUrl;
 			var statTags = [
-				"route:" + req.route.path,
+				"route:" + route,
 			].concat(tags);
 
 			if (options.method) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiivv/connect-datadog",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Datadog middleware for Connect JS / Express",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Fix crash when an invalid path is given. It appears that `req` does not have `route` when the given path is invalid. 

Change:
- Partially reverted https://github.com/wiivv/node-connect-datadog/commit/e034e97d2ce473bde4857781c03cd6d04b586aba by using `originalUrl` for the case when `req.route` is null.